### PR TITLE
flyway init - substituted yaml chunks with sql ones

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 HELP.md
 .gradle
 build/
+out/
 !gradle/wrapper/gradle-wrapper.jar
 .idea
 gradlew
 gradlew.bat
-

--- a/build.gradle
+++ b/build.gradle
@@ -10,8 +10,8 @@ plugins {
 
 group = 'com.dag'
 version = '0.0.1-SNAPSHOT'
-java.sourceCompatibility = '17'
-java.targetCompatibility = '17'
+java.sourceCompatibility = JavaVersion.VERSION_17
+java.targetCompatibility = JavaVersion.VERSION_17
 
 repositories {
     mavenCentral()
@@ -25,17 +25,13 @@ dependencies {
     implementation 'com.fasterxml.jackson.module:jackson-module-kotlin'
     implementation 'org.jetbrains.kotlin:kotlin-reflect'
     implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
+    implementation 'org.liquibase:liquibase-core'
     runtimeOnly 'org.postgresql:postgresql'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 
-tasks.withType(KotlinCompile) {
+tasks.withType(KotlinCompile).configureEach {
     kotlinOptions {
         freeCompilerArgs = ['-Xjsr305=strict']
         jvmTarget = '17'
     }
-}
-
-tasks.named('test') {
-    useJUnitPlatform()
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,0 +1,13 @@
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:5432/lets_play
+    username: postgres
+    password: postgres
+    pool-size: 5
+  jpa:
+    show-sql: true
+    hibernate:
+      ddl-auto: validate
+  liquibase:
+    enabled: false
+    change-log: classpath:liquibase/changelog.yaml

--- a/src/main/resources/liquibase/changelog.yaml
+++ b/src/main/resources/liquibase/changelog.yaml
@@ -1,0 +1,3 @@
+databaseChangeLog:
+  - includeAll:
+      path: classpath:liquibase/chunks


### PR DESCRIPTION
В общем пока flyway выключен, но это для того, чтобы на пустом sql-чанке не падал. Когда продумаем структуру БД, заполним первый чанк и включим flyway